### PR TITLE
Variable Cleanup and Validation

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,15 +1,15 @@
-# Example of how to pass variable for database password: 
+# Example of how to pass variable for database password:
 # terraform apply -var="db_password=..."
 # Environment variables can also be used https://www.terraform.io/language/values/variables#environment-variables
 variable "db_password" {
   description = "The admin password"
 }
 
-# Provision Intel Optimized AWS MySQL server 
+# Provision Intel Optimized AWS MySQL server
 module "optimized-mysql-server" {
   source      = "../"
   db_password = var.db_password
-  # Update the vpc_id below for the VPC that this module will use. Find the vpc-id in your AWS account 
+  # Update the vpc_id below for the VPC that this module will use. Find the vpc-id in your AWS account
   # from the AWS console or using CLI commands. In your AWS account, the vpc-id is represented as "vpc-",
   # followed by a set of alphanumeric characters. One sample representation of a vpc-id is vpc-0a6734z932p20c2m4
   vpc_id = "vpc-xxx"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.region
-}
-
 data "aws_subnets" "vpc_subnets" {
   filter {
     name   = "vpc-id"

--- a/variables.tf
+++ b/variables.tf
@@ -22,14 +22,6 @@ variable "aws_database_instance_class" {
   default = "db.m6i.2xlarge"
 }
 
-variable "region" {
-  description = "AWS region"
-  type        = string
-
-  ## Set the value of the aws region where the database will be created
-  default = "us-east-1"
-}
-
 variable "db_subnet_group_name" {
   description = "db subnet group name"
   type        = string


### PR DESCRIPTION
Changes:

- Moved required variables to the top
- `terraform format`
- Removed `mysql_server_name` since it was not being referenced
- Removed `availability_zone` since it was not being referenced
- Removed `family` since it was not being referenced
- Added input validation to the `aws_database_instance_class` variable to be limited to only Intel instances
- Removed `region` as this was a reference to a provider definition that we would want to remove as a part of the module
- Removed provider definition in `main.tf` as we would want this to come from the root module