### PR TITLE
Restrict AWS provider to 4.x for better compatibility

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.36.0"
+      version = "~> 4.36"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
The current version constraint is too restrictive, making it hard to consume the module along with others, this releases the constraint to enforce only the major version of the AWS provider.