### PR TITLE
Updated readme files with proper m7i instance names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## AWS RDS MySQL module
 
-Configuration in this directory creates an Amazon RDS instance for MySQL. The instance is created on an Intel Icelake instance M6i.xlarge by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
+Configuration in this directory creates an Amazon RDS instance for MySQL. The instance is created on an Intel Sapphire Rapids db.m7i.2xlarge instance by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
 
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 

--- a/examples/intel-optimized-mysql-server-expanded/README.md
+++ b/examples/intel-optimized-mysql-server-expanded/README.md
@@ -8,7 +8,7 @@
 
 ## AWS RDS MySQL module - Expanded Parameters Example
 
-Configuration in this directory creates an Amazon RDS instance for MySQL and optimizes the database parameter innodb_open_files. The instance is created on an Intel Sapphire Rapids instance M7i.2xlarge by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
+Configuration in this directory creates an Amazon RDS instance for MySQL and optimizes the database parameter innodb_open_files. The instance is created on an Intel Sapphire Rapids instance db.m7i.2xlarge by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
 
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 

--- a/examples/intel-optimized-mysql-server-replica_testing/README.md
+++ b/examples/intel-optimized-mysql-server-replica_testing/README.md
@@ -8,7 +8,7 @@
 
 ## AWS RDS MySQL module - Read Replica Example
 
-Configuration in this directory creates an Amazon RDS instance for MySQL and creates a read replica in the us-east-1 region. The instance is created on an Intel Sapphire Rapids instance M7i.2xlarge by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
+Configuration in this directory creates an Amazon RDS instance for MySQL and creates a read replica in the us-east-1 region. The instance is created on an Intel Sapphire Rapids instance db.m7i.2xlarge by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
 
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 

--- a/examples/intel-optimized-mysql-server/README.md
+++ b/examples/intel-optimized-mysql-server/README.md
@@ -8,7 +8,7 @@
 
 ## AWS RDS MySQL Module - Intel Optimized Example
 
-Configuration in this directory creates an Amazon RDS Intel optimized instance for MySQL. The instance is created on an Intel Sapphire Rapids instance M7i.2large by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
+Configuration in this directory creates an Amazon RDS Intel optimized instance for MySQL. The instance is created on an Intel Sapphire Rapids instance db.m7i.2xlarge by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
 
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 


### PR DESCRIPTION
readme files had inconsistent naming convention and the root readme still pointed to m6i instead of m7i instance. 